### PR TITLE
Build change info additional features

### DIFF
--- a/tungsten_ci_utils/generate_build_change_info/changes.html.tpl
+++ b/tungsten_ci_utils/generate_build_change_info/changes.html.tpl
@@ -6,6 +6,9 @@ td, th { border: 1px solid black; padding: 10px }
 </style>
 </head>
 <h1>Differences between builds #{{ build_number_prev }} and #{{ build_number }}</h1>
+{% if fetched_prev %}
+<h5>Build #{{ build_number_prev }} was automatically detected as the last previous successful nightly build before #{{ build_number }}
+{% endif %}
 {% for canonical_name, project  in projects.items()  %}
 <table>
 <tr>

--- a/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
+++ b/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
@@ -364,13 +364,13 @@ def fetch_json(source):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--changes-json", action="append")
-    parser.add_argument("--deployment-run", action="store_true") # a flag helpful to determine if the script was run via ansible or manually
+    parser.add_argument("--fetched-prev", action="store_true")
     parser.add_argument("branch")
     parser.add_argument("build_number")
     parser.add_argument("previous_build_number", nargs='?')
     args = parser.parse_args()
     branch = args.branch
-    deployment_run = args.deployment_run
+    fetched_prev = args.fetched_prev
 
     if args.previous_build_number is not None:
         previous_build_number, build_number = sorted([int(args.previous_build_number), int(args.build_number)])
@@ -418,7 +418,7 @@ def main():
         "build_number_prev": previous_build_number,
         "build_number": build_number,
         "bugs": bugs,
-        "deployment_run": deployment_run
+        "fetched_prev": fetched_prev
     }
     with open('changes.json', 'w') as out:
         json.dump(projects, out, indent=4)

--- a/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
+++ b/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
@@ -366,10 +366,16 @@ def main():
     parser.add_argument("--changes-json", action="append")
     parser.add_argument("branch")
     parser.add_argument("build_number")
+    parser.add_argument("previous_build_number", nargs='?')
     args = parser.parse_args()
     branch = args.branch
-    build_number = args.build_number
-    previous_build_number = str(int(build_number)-1)
+
+    if args.previous_build_number is not None:
+        previous_build_number, build_number = sorted([int(args.previous_build_number), int(args.build_number)])
+    else:
+        build_number = int(args.build_number)
+        previous_build_number = str(int(build_number)-1)
+        
 
     # if pointed to already generated json file(s), load the data and skip the
     # whole generation process directly to the html rendering step

--- a/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
+++ b/tungsten_ci_utils/generate_build_change_info/generate_build_change_info.py
@@ -364,11 +364,13 @@ def fetch_json(source):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--changes-json", action="append")
+    parser.add_argument("--deployment-run", action="store_true") # a flag helpful to determine if the script was run via ansible or manually
     parser.add_argument("branch")
     parser.add_argument("build_number")
     parser.add_argument("previous_build_number", nargs='?')
     args = parser.parse_args()
     branch = args.branch
+    deployment_run = args.deployment_run
 
     if args.previous_build_number is not None:
         previous_build_number, build_number = sorted([int(args.previous_build_number), int(args.build_number)])
@@ -415,7 +417,8 @@ def main():
         "projects": projects,
         "build_number_prev": previous_build_number,
         "build_number": build_number,
-        "bugs": bugs
+        "bugs": bugs,
+        "deployment_run": deployment_run
     }
     with open('changes.json', 'w') as out:
         json.dump(projects, out, indent=4)

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -72,14 +72,20 @@ def main():
                 last_successful = build_number
                 log.debug('last successful buildset before %s found, number: %s', og_build_number, last_successful)
                 print(last_successful)
+                break
             elif result[0][0] == 'FAILURE':
                 log.debug('buildset %s was a failure', build_number)
-                build_number -= 1
             else:
                 log.warning('unknown buildset result for current iteration (build number %s)', build_number)
         else:
-            log.debug('last successful build not found in the database')
-            break
+            log.error('buildset number %s not found in the database, aborting', build_number)
+            sys.exit(1) # we exit here, assuming there are no gaps in (incremental) build numbers
+
+        build_number -= 1
+
+    else:
+        log.error('last successful buildset not found')
+        sys.exit(1)
 
     db.close()
 

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -1,0 +1,87 @@
+import sys
+import argparse
+import MySQLdb
+import logging
+import json
+
+log = logging.getLogger(__name__)
+
+def set_logging():
+    log.setLevel(logging.DEBUG)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    console = logging.StreamHandler()
+    console.setLevel(logging.DEBUG)
+    console.setFormatter(formatter)
+    log.addHandler(console)
+
+set_logging()
+
+def get_json_data(file):
+    json_file = open(file).read()
+    data = json.loads(json_file)
+    return data
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--credentials-json", action="append")
+    parser.add_argument("branch")
+    parser.add_argument("build_number")
+    args = parser.parse_args()
+    branch = str(args.branch)
+    credentials_json = args.credentials_json[0]
+
+    build_number = int(args.build_number)
+    og_build_number = build_number
+    build_number -= 1
+
+    db_config = get_json_data(credentials_json)
+
+    try:
+        db = MySQLdb.connect(
+            user=db_config["user"],
+            passwd=db_config["passwd"],
+            db=db_config["db"],
+            host=db_config["host"],
+            port=db_config["port"]
+        )
+        cur = db.cursor()
+    except:
+        log.error('Database connection error')
+        sys.exit(1)
+
+    last_successful = False
+
+    while (build_number > 0) and (not last_successful):
+        query = """
+        SELECT result FROM zuul_buildset WHERE id IN 
+        (SELECT buildset_id FROM zuul_build WHERE log_url LIKE CONCAT('%%periodic-nightly%%/', %s, '/%s%%'))
+        """
+
+        log.debug('checking if buildset %s was successful', build_number)
+
+        try:
+            cur.execute(query, (branch, build_number))
+            result = list(cur)
+        except:
+            log.error('Query execution error')
+            sys.exit(1)
+
+        if len(result) > 0:
+            if result[0][0] == 'SUCCESS':
+                last_successful = build_number
+                log.debug('last successful buildset before %s found, number: %s', og_build_number, last_successful)
+                print(last_successful)
+            elif result[0][0] == 'FAILURE':
+                log.debug('buildset %s was a failure', build_number)
+                build_number -= 1
+            else:
+                log.warning('unknown buildset result for current iteration (build number %s)', build_number)
+        else:
+            log.debug('last successful build not found in the database')
+            break
+
+    db.close()
+
+if __name__ == '__main__':
+    main()

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -8,11 +8,11 @@ import re
 log = logging.getLogger(__name__)
 
 def set_logging():
-    log.setLevel(logging.DEBUG)
+    log.setLevel(logging.INFO)
     formatter = logging.Formatter(
         '%(asctime)s - %(levelname)s - %(message)s')
     console = logging.StreamHandler()
-    console.setLevel(logging.DEBUG)
+    console.setLevel(logging.INFO)
     console.setFormatter(formatter)
     log.addHandler(console)
 
@@ -50,44 +50,45 @@ def main():
             port=db_config["port"]
         )
         cur = db.cursor()
+        log.info('connected to db')
     except:
         log.error('database connection error')
         sys.exit(1)
 
     query_get_buildset = """
-    SELECT max(buildset_id), max(end_time) FROM zuul_build
-    WHERE log_url LIKE CONCAT('%%', %s, '/%s/%%')
-    """
+                              SELECT max(buildset_id), max(end_time) FROM zuul_build
+                              WHERE log_url LIKE CONCAT('%%', %s, '/%s/%%')
+                         """
 
     query_success_id = """
-    SELECT max(buildset_id) FROM zuul_buildset
-    JOIN zuul_build ON zuul_buildset.id = zuul_build.buildset_id
-    WHERE zuul_buildset.result = 'SUCCESS'
-    AND zuul_buildset.pipeline = 'periodic-nightly'
-    AND zuul_buildset.ref LIKE CONCAT('refs/heads/', %s)
-    AND zuul_buildset.id < %s
-    AND zuul_build.end_time < %s
-    """
+                            SELECT max(buildset_id) FROM zuul_buildset
+                            JOIN zuul_build ON zuul_buildset.id = zuul_build.buildset_id
+                            WHERE zuul_buildset.result = 'SUCCESS'
+                                AND zuul_buildset.pipeline = 'periodic-nightly'
+                                AND zuul_buildset.ref LIKE CONCAT('refs/heads/', %s)
+                                AND zuul_buildset.id < %s
+                                AND zuul_build.end_time < %s
+                       """
 
     query_success_log_url = """
-    SELECT log_url FROM zuul_build
-    WHERE buildset_id = %s
-    ORDER BY end_time DESC
-    LIMIT 1
-    """
+                                SELECT log_url FROM zuul_build
+                                WHERE buildset_id = %s
+                                ORDER BY end_time DESC
+                                LIMIT 1
+                            """
 
     try:
         log.debug('getting zuul buildset_id and end_time for current build number')
         cur.execute(query_get_buildset, (branch, build_number))
-        current_buildset_id, end_time = list(cur)[0]
-                
+        current_buildset_id, end_time = cur.fetchone()
+
         log.debug('getting id of last successful buildset before current')
         cur.execute(query_success_id, (branch, current_buildset_id, end_time))
-        last_success_id = list(cur)[0][0]
+        last_success_id = cur.fetchone()
 
         log.debug('getting log url of last successful buildset')
         cur.execute(query_success_log_url,(last_success_id,))
-        log_url = list(cur)[0][0]
+        log_url = str(cur.fetchone())
 
     except MySQLdb.OperationalError:
         log.error('error executing query, aborting')
@@ -104,6 +105,7 @@ def main():
     finally:
         cur.close()
         db.close()
+        log.info('db connection closed')
     
     last_successful = get_build_number_from_log_url(log_url,branch)
     print(last_successful)

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -36,8 +36,7 @@ def main():
     branch = str(args.branch)
     credentials_json = args.credentials_json[0]
 
-    build_number = int(args.build_number)
-    og_build_number = build_number
+    build_number = og_build_number = int(args.build_number)
     build_number -= 1
 
     db_config = get_json_data(credentials_json)
@@ -56,9 +55,7 @@ def main():
         log.error('database connection error')
         sys.exit(1)
 
-    last_successful = False
-
-    while (build_number > 0) and (not last_successful):
+    while build_number > 0:
         query = """
         SELECT result FROM zuul_buildset WHERE id IN 
         (SELECT buildset_id FROM zuul_build WHERE log_url LIKE CONCAT('%%periodic-nightly%%/', %s, '/%s%%'))

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -45,7 +45,8 @@ def get_log_url(cur,query,id):
     log_url = list(cur)[0][0]
     return log_url
 
-def build_number_from_log_url(regex,log_url):
+def get_build_number_from_log_url(log_url,branch):
+    regex = '(?<=' + branch + '\/)(.*?)(?=\/)'
     return re.search(regex, log_url).group(1)
 
 def main():
@@ -120,9 +121,7 @@ def main():
 
     db.close()
     
-    regex = '(?<=' + branch + '\/)(.*?)(?=\/)'
-    last_successful = build_number_from_log_url(regex,log_url)
-
+    last_successful = get_build_number_from_log_url(log_url,branch)
     print(last_successful)
 
 if __name__ == '__main__':

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -109,7 +109,7 @@ def main():
         log.error('error executing query, aborting')
         close_db_exit_err(db)
     except IndexError:
-        log.error('invalid values fetched from database, aborting')
+        log.error('invalid values fetched from database or last successful buildset not found, aborting')
         close_db_exit_err(db)
     except:
         log.error('unknown error (not raising exception)')

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -66,7 +66,7 @@ def main():
     AND zuul_buildset.pipeline = 'periodic-nightly'
     AND zuul_buildset.ref LIKE CONCAT('refs/heads/', %s)
     AND zuul_buildset.id < %s
-    AND zuul_build.end_time < %s;
+    AND zuul_build.end_time < %s
     """
 
     query_success_log_url = """

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -23,16 +23,10 @@ def get_json_data(file):
         data = json.load(json_file)
     return data
 
-def close_db_exit_err(db):
-    #raise
-    if db is not None:
-        db.close()
-        log.debug('db connection closed')
-    sys.exit(1)
-
 def get_build_number_from_log_url(log_url,branch):
     regex = '(?<=' + branch + '\/)(.*?)(?=\/)'
-    return int(re.search(regex, log_url).group(1))
+    number = re.search(regex, log_url).group(1)
+    return number
 
 def main():
     parser = argparse.ArgumentParser()
@@ -97,17 +91,19 @@ def main():
 
     except MySQLdb.OperationalError:
         log.error('error executing query, aborting')
-        close_db_exit_err(db)
+        sys.exit(1)
 
     except IndexError:
         log.error('invalid values fetched from database or last successful buildset not found, aborting')
-        close_db_exit_err(db)
+        sys.exit(1)
 
     except:
         log.error('unknown error (not raising exception)')
-        close_db_exit_err(db)
+        sys.exit(1)
 
-    db.close()
+    finally:
+        cur.close()
+        db.close()
     
     last_successful = get_build_number_from_log_url(log_url,branch)
     print(last_successful)

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -72,14 +72,21 @@ def main():
                 last_successful = build_number
                 log.debug('last successful buildset before %s found, number: %s', og_build_number, last_successful)
                 print(last_successful)
+                break
             elif result[0][0] == 'FAILURE':
                 log.debug('buildset %s was a failure', build_number)
-                build_number -= 1
             else:
                 log.warning('unknown buildset result for current iteration (build number %s)', build_number)
         else:
-            log.debug('last successful build not found in the database')
-            break
+            log.error('buildset number %s not found in the database, aborting', build_number)
+            sys.exit(1) # we exit here, assuming there are no gaps in (incremental) build numbers
+
+        build_number -= 1
+
+    else:
+        log.error('last successful buildset not found')
+        db.close()
+        sys.exit(1)
 
     db.close()
 

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -105,12 +105,15 @@ def main():
 
         log.debug('getting log url of last successful buildset')
         log_url = get_log_url(cur, query_success_log_url, last_success_id)
+
     except MySQLdb.OperationalError:
         log.error('error executing query, aborting')
         close_db_exit_err(db)
+
     except IndexError:
         log.error('invalid values fetched from database or last successful buildset not found, aborting')
         close_db_exit_err(db)
+
     except:
         log.error('unknown error (not raising exception)')
         close_db_exit_err(db)

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -3,13 +3,14 @@ import argparse
 import MySQLdb
 import logging
 import json
+import re
 
 log = logging.getLogger(__name__)
 
 def set_logging():
     log.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        '%(asctime)s - %(levelname)s - %(message)s')
     console = logging.StreamHandler()
     console.setLevel(logging.DEBUG)
     console.setFormatter(formatter)
@@ -18,26 +19,45 @@ def set_logging():
 set_logging()
 
 def get_json_data(file):
-    json_file = open(file).read()
-    data = json.loads(json_file)
+    with open(file, 'r') as json_file:
+        data = json.load(json_file)
     return data
 
 def close_db_exit_err(db):
+    #raise
     if db is not None:
         db.close()
+        log.debug('db connection closed')
     sys.exit(1)
+
+def get_current_buildset_info(cur,query,branch,build_number):
+    cur.execute(query, (branch, build_number))
+    buildset_id, end_time = list(cur)[0]
+    return buildset_id,end_time
+
+def get_last_successful_buildset_info(cur,query,branch,current_id,end_time):
+    cur.execute(query, (branch, current_id, end_time))
+    success_id = list(cur)[0][0]
+    return success_id
+
+def get_log_url(cur,query,id):
+    cur.execute(query,(id,))
+    log_url = list(cur)[0][0]
+    return log_url
+
+def build_number_from_log_url(regex,log_url):
+    return re.search(regex, log_url).group(1)
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--credentials-json", action="append")
+    parser.add_argument("--credentials-json")
     parser.add_argument("branch")
-    parser.add_argument("build_number")
+    parser.add_argument("build_number", type=int)
     args = parser.parse_args()
-    branch = str(args.branch)
-    credentials_json = args.credentials_json[0]
 
-    build_number = og_build_number = int(args.build_number)
-    build_number -= 1
+    branch = str(args.branch)
+    build_number = args.build_number
+    credentials_json = args.credentials_json
 
     db_config = get_json_data(credentials_json)
 
@@ -50,46 +70,57 @@ def main():
             port=db_config["port"]
         )
         cur = db.cursor()
-        log.debug('connected to db')
     except:
         log.error('database connection error')
         sys.exit(1)
 
-    while build_number > 0:
-        query = """
-        SELECT result FROM zuul_buildset WHERE id IN 
-        (SELECT buildset_id FROM zuul_build WHERE log_url LIKE CONCAT('%%periodic-nightly%%/', %s, '/%s%%'))
-        """
+    query_get_buildset = """
+    SELECT max(buildset_id), max(end_time) FROM zuul_build
+    WHERE log_url LIKE CONCAT('%%', %s, '/%s/%%')
+    """
 
-        log.debug('checking if buildset %s was successful', build_number)
+    query_success_id = """
+    SELECT max(buildset_id) FROM zuul_buildset
+    JOIN zuul_build ON zuul_buildset.id = zuul_build.buildset_id
+    WHERE zuul_buildset.result = 'SUCCESS'
+    AND zuul_buildset.pipeline = 'periodic-nightly'
+    AND zuul_buildset.ref LIKE CONCAT('refs/heads/', %s)
+    AND zuul_buildset.id < %s
+    AND zuul_build.end_time < %s;
+    """
 
-        try:
-            cur.execute(query, (branch, build_number))
-            result = list(cur)
-        except:
-            log.error('Query execution error')
-            close_db_exit_err(db)
+    query_success_log_url = """
+    SELECT log_url FROM zuul_build
+    WHERE buildset_id = %s
+    ORDER BY end_time DESC
+    LIMIT 1
+    """
 
-        if len(result) > 0:
-            if result[0][0] == 'SUCCESS':
-                log.debug('last successful buildset before %s found, number: %s', og_build_number, build_number)
-                print(build_number)
-                break
-            elif result[0][0] == 'FAILURE':
-                log.debug('buildset %s was a failure', build_number)
-            else:
-                log.warning('unknown buildset result for current iteration (build number %s)', build_number)
-        else:
-            log.error('buildset number %s not found in the database, aborting', build_number)
-            close_db_exit_err(db) # we exit here, assuming there are no gaps in (incremental) build numbers
+    try:
+        log.debug('getting zuul buildset_id and end_time for current build number')
+        current_buildset_id, end_time = get_current_buildset_info(cur, query_get_buildset, branch, build_number)
 
-        build_number -= 1
+        log.debug('getting id of last successful buildset before current')
+        last_success_id = get_last_successful_buildset_info(cur, query_success_id, branch, current_buildset_id, end_time)
 
-    else:
-        log.error('last successful buildset not found')
+        log.debug('getting log url of last successful buildset')
+        log_url = get_log_url(cur, query_success_log_url, last_success_id)
+    except MySQLdb.OperationalError:
+        log.error('error executing query, aborting')
+        close_db_exit_err(db)
+    except IndexError:
+        log.error('invalid values fetched from database, aborting')
+        close_db_exit_err(db)
+    except:
+        log.error('unknown error (not raising exception)')
         close_db_exit_err(db)
 
     db.close()
+    
+    regex = '(?<=' + branch + '\/)(.*?)(?=\/)'
+    last_successful = build_number_from_log_url(regex,log_url)
+
+    print(last_successful)
 
 if __name__ == '__main__':
     main()

--- a/tungsten_ci_utils/generate_build_change_info/last_successful.py
+++ b/tungsten_ci_utils/generate_build_change_info/last_successful.py
@@ -72,9 +72,8 @@ def main():
 
         if len(result) > 0:
             if result[0][0] == 'SUCCESS':
-                last_successful = build_number
-                log.debug('last successful buildset before %s found, number: %s', og_build_number, last_successful)
-                print(last_successful)
+                log.debug('last successful buildset before %s found, number: %s', og_build_number, build_number)
+                print(build_number)
                 break
             elif result[0][0] == 'FAILURE':
                 log.debug('buildset %s was a failure', build_number)

--- a/tungsten_ci_utils/generate_build_change_info/requirements.txt
+++ b/tungsten_ci_utils/generate_build_change_info/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==3.13
 requests==2.19.1
 six==1.11.0
 urllib3==1.23
+MySQL-python==1.2.5

--- a/tungsten_ci_utils/generate_build_change_info/requirements.txt
+++ b/tungsten_ci_utils/generate_build_change_info/requirements.txt
@@ -2,9 +2,11 @@ certifi==2018.4.16
 cffi==1.11.5
 chardet==3.0.4
 idna==2.7
-pycparser==2.18
+pycparser<2.17
 PyYAML==3.13
 requests==2.19.1
 six==1.11.0
 urllib3==1.23
-MySQL-python==1.2.5
+Jinja2==2.10
+pygit2==0.28.0
+#MySQL-python==1.2.5 #optional (if you want to use last_successful.py)


### PR DESCRIPTION
Modified generate_build_change_info.py to take input of two builds instead of one (and decreasing the second build number by 1). Added last_successful.py script which queries the database looking for the last successful periodic-nightly build before the current one.